### PR TITLE
Add x checker data for boost

### DIFF
--- a/org.kde.ktorrent.json
+++ b/org.kde.ktorrent.json
@@ -32,7 +32,13 @@
                 {
                     "type": "archive",
                     "url": "https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.tar.bz2",
-                    "sha256": "8681f175d4bdb26c52222665793eef08490d7758529330f98d3b29dd0735bccc"
+                    "sha256": "8681f175d4bdb26c52222665793eef08490d7758529330f98d3b29dd0735bccc",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 6845,
+                        "stable-only": true,
+                        "url-template": "https://boostorg.jfrog.io/artifactory/main/release/$version/source/boost_${major}_${minor}_$patch.tar.bz2"
+                    }
                 }
             ]
         },


### PR DESCRIPTION
Added x-data-checker tag for boost

Output when using 1.76.0

```
INFO    src.manifest: Checking 1 external data items
INFO    src.manifest: Started check [1/1] archive boost_1_76_0.tar.bz2 (from boost.json)
INFO    src.lib.externaldata: Source boost_1_76_0.tar.bz2: got new version 1.78.0
INFO    src.manifest: Finished check [1/1] archive boost_1_76_0.tar.bz2 (from boost.json)
CHANGE SOON: boost_1_76_0.tar.bz2
 Has a new version:
  URL:       https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.tar.bz2
  MD5:       db0112a3a37a3742326471d20f1a186a
  SHA1:      7ccc47e82926be693810a687015ddc490b49296d
  SHA256:    8681f175d4bdb26c52222665793eef08490d7758529330f98d3b29dd0735bccc
  SHA512:    9c34a387a203b99aa773eb0c59f5abac7a99ba10e4623653e793c1d5b29b99b88e0e4e0d4e2e4ca5d497c42f2e46e23bab66417722433a457dc818d7670bcbbf
  Size:      110675550
  Version:   1.78.0
  Timestamp: 2021-12-02 07:20:20

INFO    src.main: Check finished with 0 error(s)
```