### PR TITLE
removed host filesystem access, replaced with sane locations

### DIFF
--- a/org.kde.ktorrent.json
+++ b/org.kde.ktorrent.json
@@ -7,7 +7,12 @@
     "rename-icon": "ktorrent",
     "finish-args": [
         "--device=dri",
-        "--filesystem=host",
+        "--filesystem=home",
+        "--filesystem=/media",
+        "--filesystem=/mnt",
+        "--filesystem=/run/media",
+        "--filesystem=/var/run/media",
+        "--filesystem=/var/mnt",
         "--share=ipc",
         "--share=network",
         "--socket=fallback-x11",


### PR DESCRIPTION
it should not have host access

This is not hardening, its simply all the locations media file actually are at. Its a start for easier hardening also for users

  - --filesystem=home
  - --filesystem=/media
  - --filesystem=/mnt
  - --filesystem=/run/media
  - --filesystem=/var/run/media
  - --filesystem=/var/mnt